### PR TITLE
fix: bypass selection change when refreshing treeview

### DIFF
--- a/src/ObjectListView/DragDrop/DropSink.cs
+++ b/src/ObjectListView/DragDrop/DropSink.cs
@@ -632,10 +632,18 @@ namespace BrightIdeasSoftware
         /// </summary>
         /// <param name="args"></param>
         public override void Drop(DragEventArgs args) {
-            this.dropEventArgs.DragEventArgs = args;
-            this.TriggerDroppedEvent(args);
-            this.timer.Stop();
-            this.Cleanup();
+            var modelDropEventArgs = this.dropEventArgs;
+            if (modelDropEventArgs != null)
+            {
+                modelDropEventArgs.DragEventArgs = args;
+                this.TriggerDroppedEvent(args);
+                this.timer.Stop();
+                this.Cleanup();
+            }
+            else
+            {
+                throw new ArgumentNullException("dropEventArgs is null.");
+            }
         }
 
         /// <summary>

--- a/src/ObjectListView/ObjectListView.cs
+++ b/src/ObjectListView/ObjectListView.cs
@@ -2986,6 +2986,11 @@ namespace BrightIdeasSoftware
         }
 
         /// <summary>
+        /// When it is true the SelectionChange will bypassed.
+        /// </summary>
+        public bool BypassSelectionChange { get; set; } = false;
+
+        /// <summary>
         /// When the user right clicks on the column headers, should a menu be presented which will allow
         /// them to choose common tasks to perform on the listview?
         /// </summary>
@@ -9407,11 +9412,11 @@ namespace BrightIdeasSoftware
         /// </summary>
         /// <param name="e"></param>
         protected override void OnSelectedIndexChanged(EventArgs e) {
-            if (this.SelectionEventsSuspended)
+            if (this.SelectionEventsSuspended || this.BypassSelectionChange)
                 return;
 
             base.OnSelectedIndexChanged(e);
-
+            
             // If we haven't already scheduled an event, schedule it to be triggered
             // By using idle time, we will wait until all select events for the same
             // user action have finished before triggering the event.
@@ -10620,7 +10625,7 @@ namespace BrightIdeasSoftware
         }
 
         private bool ShouldShowOverlays() {
-            // If we are in design mode, we don’t show the overlays
+            // If we are in design mode, we donï¿½t show the overlays
             if (this.DesignMode)
                 return false;
 

--- a/src/ObjectListView/TreeListView.cs
+++ b/src/ObjectListView/TreeListView.cs
@@ -816,7 +816,15 @@ namespace BrightIdeasSoftware
 
             this.ClearCachedInfo();
             this.UpdateVirtualListSize();
-            this.SelectedObjects = selection;
+            try
+            {
+                BypassSelectionChange = true;
+                this.SelectedObjects = selection;
+            }
+            finally
+            {
+                BypassSelectionChange = false;
+            }
 
             // Redraw everything from the first update to the end of the list
             this.RedrawItems(firstChange, this.GetItemCount() - 1, true);


### PR DESCRIPTION
 While refreshing the treeview, it sets the SelectedObjects and it invokes the SelectionChange event and finally we have selection change not ItemCheck! so this new field bypasses the event in this case.