### PR TITLE
Fix error cast from ListViewDesigner to ControlDesigner on Visual Stu…

### DIFF
--- a/ObjectListView/ObjectListView.DesignTime.cs
+++ b/ObjectListView/ObjectListView.DesignTime.cs
@@ -75,12 +75,26 @@ namespace BrightIdeasSoftware.Design
 
             // Use reflection to bypass the "internal" marker on ListViewDesigner
             // If we can't get the unversioned designer, look specifically for .NET 4.0 version of it.
-            Type tListViewDesigner = Type.GetType("System.Windows.Forms.Design.ListViewDesigner, System.Design") ??
+            Type tListViewDesigner = null;
+            try
+            {
+                tListViewDesigner = Type.GetType("System.Windows.Forms.Design.ListViewDesigner, System.Design") ??
                                      Type.GetType("System.Windows.Forms.Design.ListViewDesigner, System.Design, " +
                                                   "Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
-            if (tListViewDesigner == null) throw new ArgumentException("Could not load ListViewDesigner");
+                this.listViewDesigner = (ControlDesigner)Activator.CreateInstance(tListViewDesigner, BindingFlags.Instance | BindingFlags.Public, null, null, null);
+            }
+            catch(ArgumentNullException ex)
+            {
+                throw ex;
+            }
+            catch(InvalidCastException)
+            {
+                // Fix error cast ListViewDesigner to ControlDesigner on Visual Studio 2017 Express Designer
+                //  "Unable to cast object of type System.Windows.Forms.Designer.ListViewDesigner to type System.Windows.Forms.Design.ControlDesigner"
+                tListViewDesigner = Type.GetType("System.Windows.Forms.Design.ListViewDesigner");
+                this.listViewDesigner = (ControlDesigner)Activator.CreateInstance(tListViewDesigner, BindingFlags.Instance | BindingFlags.Public, null, null, null);
+            }
 
-            this.listViewDesigner = (ControlDesigner)Activator.CreateInstance(tListViewDesigner, BindingFlags.Instance | BindingFlags.Public, null, null, null);
             this.designerFilter = this.listViewDesigner;
 
             // Fetch the methods from the ListViewDesigner that we know we want to use


### PR DESCRIPTION
Fix error cast from ListViewDesigner to ControlDesigner on Visual Studio 2017 Express Designer

"Unable to cast object of type System.Windows.Forms.Designer.ListViewDesigner to type System.Windows.Forms.Design.ControlDesigner"