### PR TITLE
Fix System.NullReferenceException in TreeRenderer.HandleHitTest

### DIFF
--- a/ObjectListView/Rendering/TreeRenderer.cs
+++ b/ObjectListView/Rendering/TreeRenderer.cs
@@ -267,8 +267,12 @@ namespace BrightIdeasSoftware {
             /// <param name="x"></param>
             /// <param name="y"></param>
             protected override void HandleHitTest(Graphics g, OlvListViewHitTestInfo hti, int x, int y) {
-                Branch br = this.Branch;
 
+                if (g == null || hti == null) return;
+                
+                Branch br = this.Branch;
+                if (br == null) return;
+                
                 Rectangle r = this.ApplyCellPadding(this.Bounds);
                 if (br.CanExpand) {
                     r.Offset((br.Level - 1) * PIXELS_PER_LEVEL, 0);


### PR DESCRIPTION
Fix System.NullReferenceException in BrightIdeasSoftware.TreeListView.TreeRenderer.HandleHitTest

Exception Details:

[Error Code]
0x80004003

[Message]
Object reference not set to an instance of an object.

[Source]
ObjectListView

[Target Site]
Void HandleHitTest(System.Drawing.Graphics, BrightIdeasSoftware.OlvListViewHitTestInfo, Int32, Int32)

[Stack Trace]
   at BrightIdeasSoftware.TreeListView.TreeRenderer.HandleHitTest(Graphics g, OlvListViewHitTestInfo hti, Int32 x, Int32 y)
   at BrightIdeasSoftware.BaseRenderer.HitTest(OlvListViewHitTestInfo hti, Int32 x, Int32 y)
   at BrightIdeasSoftware.ObjectListView.CalculateOwnerDrawnHitTest(OlvListViewHitTestInfo hti, Int32 x, Int32 y)
   at BrightIdeasSoftware.ObjectListView.OlvHitTest(Int32 x, Int32 y)
   at BrightIdeasSoftware.ObjectListView.BuildCellEvent(CellEventArgs args, Point location)
   at BrightIdeasSoftware.ObjectListView.HandleMouseMove(Point pt)
   at BrightIdeasSoftware.ObjectListView.OnMouseMove(MouseEventArgs e)
   at System.Windows.Forms.Control.WmMouseMove(Message& m)
   at System.Windows.Forms.Control.WndProc(Message& m)
   at System.Windows.Forms.ListView.WndProc(Message& m)
   at BrightIdeasSoftware.ObjectListView.WndProc(Message& m)